### PR TITLE
Notifying mixin

### DIFF
--- a/computing-lit-element.js
+++ b/computing-lit-element.js
@@ -1,5 +1,14 @@
 import { computingMixin } from './src/computingMixin.js';
+import { notifyingMixin } from './src/notifyingMixin.js';
 import { LitElement, html } from 'lit-element';
 
-const ComputingLitElement = computingMixin(LitElement);
-export { ComputingLitElement, html, computingMixin };
+const ComputingLitElement = computingMixin(LitElement),
+	NotifyingLitElement = notifyingMixin(LitElement);
+
+export {
+	ComputingLitElement,
+	NotifyingLitElement,
+	html,
+	computingMixin,
+	notifyingMixin
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,7 +801,12 @@
     "@neovici/eslint-config": {
       "version": "github:neovici/eslint-config#695cb4df0718a8972b70f7e2dd3bdc645f249d43",
       "from": "github:neovici/eslint-config#semver:^1.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-eslint": ">= 10",
+        "eslint-plugin-html": ">= 5",
+        "eslint-plugin-import": ">= 2"
+      }
     },
     "@open-wc/building-utils": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neovici/computing-lit-element",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Add computed properties to LitElement",
   "author": "Neovici",
   "homepage": "https://github.com/Neovici/computing-lit-element#readme",

--- a/src/notifyingMixin.js
+++ b/src/notifyingMixin.js
@@ -1,0 +1,35 @@
+const CHANGED_EVENT_TYPE_REGEXP = /(.*)-changed/u,
+	kebabCase = input => input.replace(/([a-z0-9])([A-Z])/gu, '$1-$2').toLowerCase(),
+	notifyingMixin = baseClass =>
+		class extends baseClass {
+			constructor() {
+				super();
+
+				this.__notifyingProps = Object.entries(this.constructor.properties)
+					.filter(([, value]) => value.notify === true)
+					.map(([key]) => key);
+			}
+			notifyUpdateHelper(event) {
+				const eventTypeRegexp = CHANGED_EVENT_TYPE_REGEXP.exec(event.type);
+				if (eventTypeRegexp == null) {
+					return;
+				}
+				const propUpdated = eventTypeRegexp[1];
+				this[propUpdated] = event.detail.value;
+			}
+			updated(changedProperties) {
+				super.updated();
+				this.__notifyingProps
+					.filter(prop => changedProperties.has(prop))
+					.forEach(prop => {
+						this.dispatchEvent(new CustomEvent(`${ kebabCase(prop) }-changed`, {
+							composed: true,
+							detail: {
+								value: this[prop]
+							}
+						}));
+					});
+			}
+		};
+
+export { notifyingMixin };


### PR DESCRIPTION
Add a mixin to emulate Polymer behavior when defining element
properties with `notify: true` (fire prop-changed events)
Also add a helper in that behavior to make a prop-changed
event update prop. (Polymer 2-way bindings)